### PR TITLE
Update Fall2024.astro to include proper project urls

### DIFF
--- a/src/semesters/Fall2024.astro
+++ b/src/semesters/Fall2024.astro
@@ -23,15 +23,15 @@ const items = [
     submenu: [
       {
         title: "Linux",
-        url: "/projects/coming-soon",
+        url: "/projects/linux",
       },
       {
         title: "Exploit and Patch",
-        url: "/projects/coming-soon",
+        url: "/projects/exploit-and-patch",
       },
       {
-        title: "Encryption",
-        url: "/projects/coming-soon",
+        title: "Encrypted Communication",
+        url: "/projects/encrypted-communication",
       },
       {
         title: "Password Vault",


### PR DESCRIPTION
I wanted to be able to quickly access the project page without having to scroll through the schedule. Hopefully other students find this useful as well!